### PR TITLE
fix: sonarqube cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ Opinionated action for dotnet workflows. Restores, checks formatting, lints, bui
 
 ## Inputs
 
-| Name                 | Description                             | Required | Default |
-|----------------------|-----------------------------------------|----------|---------|
-| working-directory    | The directory to run dotnet commands in | Yes      |         |
-| dotnet-version       | The version of dotnet to use            | No       | 10.0.x  |
-| enable-sonar         | Enable SonarQube analysis              | No       | false   |
-| sonar-token          | SonarQube token                        | No       |         |
-| sonar-project-key    | SonarQube project key                  | No       |         |
-| sonar-organization   | SonarQube organization                 | No       |         |
+| Name               | Description                             | Required | Default |
+|--------------------|-----------------------------------------|----------|---------|
+| working-directory  | The directory to run dotnet commands in | Yes      |         |
+| dotnet-version     | The version of dotnet to use            | No       | 10.0.x  |
+| enable-sonar       | Enable SonarQube analysis               | No       | false   |
+| sonar-token        | SonarQube token                         | No       |         |
+| sonar-project-key  | SonarQube project key                   | No       |         |
+| sonar-organization | SonarQube organization                  | No       |         |
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@ Opinionated action for dotnet workflows. Restores, checks formatting, lints, bui
 
 ## Inputs
 
-| Name               | Description                                                                                                    | Required | Default |
-|--------------------|----------------------------------------------------------------------------------------------------------------|----------|---------|
-| working-directory  | The directory to run dotnet commands in                                                                        | Yes      |         |
-| dotnet-version     | The version of dotnet to use                                                                                   | No       | 10.0.x  |
-| enable-sonar       | Enable SonarQube analysis                                                                                      | No       | false   |
-| sonar-token        | SonarQube token                                                                                                | No       |         |
-| sonar-organization | SonarQube organization                                                                                         | No       |         |
-| sonar-project-key  | SonarQube project key                                                                                          | No       |         |
-| sonar-exclusions   | Comma-separated list of file patterns to exclude from SonarQube analysis (e.g., '**/Migrations/**,**/obj/**')" | No       |         |
+| Name               | Description                                                                                                     | Required            | Default |
+|--------------------|-----------------------------------------------------------------------------------------------------------------|---------------------|---------|
+| working-directory  | The directory to run dotnet commands in                                                                         | Yes                 |         |
+| dotnet-version     | The version of dotnet to use                                                                                    | No                  | 10.0.x  |
+| enable-sonar       | Enable SonarQube analysis                                                                                       | No                  | false   |
+| sonar-token        | SonarQube token                                                                                                 | Yes if enable-sonar |         |
+| sonar-organization | SonarQube organization                                                                                          | Yes if enable-sonar |         |
+| sonar-project-key  | SonarQube project key                                                                                           | Yes if enable-sonar |         |
+| sonar-exclusions   | Comma-separated list of file patterns to exclude from SonarQube analysis (e.g., '**/Migrations/**,**/Utils/**') | No                  |         |
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Arbeidstilsynet/action-dotnet-build
 
-Opinionated action for dotnet workflows. Restores, checks formatting, lints, builds, and tests a .NET solution/project.
+Opinionated action for dotnet workflows. Restores, checks formatting, lints, builds, and tests a .NET solution/project. Can optionally run SonarQube Cloud analysis.
 
 ## Requirements
 
@@ -10,14 +10,15 @@ Opinionated action for dotnet workflows. Restores, checks formatting, lints, bui
 
 ## Inputs
 
-| Name               | Description                             | Required | Default |
-|--------------------|-----------------------------------------|----------|---------|
-| working-directory  | The directory to run dotnet commands in | Yes      |         |
-| dotnet-version     | The version of dotnet to use            | No       | 10.0.x  |
-| enable-sonar       | Enable SonarQube analysis               | No       | false   |
-| sonar-token        | SonarQube token                         | No       |         |
-| sonar-project-key  | SonarQube project key                   | No       |         |
-| sonar-organization | SonarQube organization                  | No       |         |
+| Name               | Description                                                                                                    | Required | Default |
+|--------------------|----------------------------------------------------------------------------------------------------------------|----------|---------|
+| working-directory  | The directory to run dotnet commands in                                                                        | Yes      |         |
+| dotnet-version     | The version of dotnet to use                                                                                   | No       | 10.0.x  |
+| enable-sonar       | Enable SonarQube analysis                                                                                      | No       | false   |
+| sonar-token        | SonarQube token                                                                                                | No       |         |
+| sonar-organization | SonarQube organization                                                                                         | No       |         |
+| sonar-project-key  | SonarQube project key                                                                                          | No       |         |
+| sonar-exclusions   | Comma-separated list of file patterns to exclude from SonarQube analysis (e.g., '**/Migrations/**,**/obj/**')" | No       |         |
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: Arbeidstilsynet/action-dotnet-build@v2
+      - uses: Arbeidstilsynet/action-dotnet-build@v4
         with:
           working-directory: ./src
 ```
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0 # Shallow clones should be disabled for better analysis relevancy
-      - uses: Arbeidstilsynet/action-dotnet-build@v2
+      - uses: Arbeidstilsynet/action-dotnet-build@v4
         with:
           working-directory: ./src
           enable-sonar: 'true'

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Opinionated action for dotnet workflows. Restores, checks formatting, lints, bui
 
 - The `working-directory` must contain a single .NET solution or project compatible with the specified .NET SDK version.
 - [CSharpier](https://csharpier.com) must be installed in the working directory or an ancestor directory (e.g., via `dotnet tool install csharpier --create-manifest-if-needed`).
-- From v3 onwards, this action uses [Microsoft Testing Platform v2](https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-platform-intro) as the test runner. Code coverage is generated in Cobertura format for SonarQube compatibility. For xUnit integration, see [xUnit with Microsoft Testing Platform](https://xunit.net/docs/getting-started/v3/microsoft-testing-platform).
+- From v3 onwards, this action uses [Microsoft Testing Platform v2](https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-platform-intro) as the test runner. Code coverage is generated in OpenCover format for SonarQube compatibility. For xUnit integration, see [xUnit with Microsoft Testing Platform](https://xunit.net/docs/getting-started/v3/microsoft-testing-platform).
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Opinionated action for dotnet workflows. Restores, checks formatting, lints, bui
 |----------------------|-----------------------------------------|----------|---------|
 | working-directory    | The directory to run dotnet commands in | Yes      |         |
 | dotnet-version       | The version of dotnet to use            | No       | 10.0.x  |
-| enable-sonar         | Enable SonarCube analysis              | No       | false   |
-| sonar-token          | SonarCube token                        | No       |         |
-| sonar-project-key    | SonarCube project key                  | No       |         |
-| sonar-organization   | SonarCube organization                 | No       |         |
+| enable-sonar         | Enable SonarQube analysis              | No       | false   |
+| sonar-token          | SonarQube token                        | No       |         |
+| sonar-project-key    | SonarQube project key                  | No       |         |
+| sonar-organization   | SonarQube organization                 | No       |         |
 
 ## Usage
 
@@ -34,7 +34,7 @@ jobs:
           working-directory: ./src
 ```
 
-### With SonarCube Integration
+### With SonarQube Integration
 
 ```yaml
 jobs:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Opinionated action for dotnet workflows. Restores, checks formatting, lints, bui
 
 - The `working-directory` must contain a single .NET solution or project compatible with the specified .NET SDK version.
 - [CSharpier](https://csharpier.com) must be installed in the working directory or an ancestor directory (e.g., via `dotnet tool install csharpier --create-manifest-if-needed`).
-- From v3 onwards, this action uses [Microsoft Testing Platform v2](https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-platform-intro) as the test runner and generates code coverage based on it. For xUnit integration, see [xUnit with Microsoft Testing Platform](https://xunit.net/docs/getting-started/v3/microsoft-testing-platform).
+- From v3 onwards, this action uses [Microsoft Testing Platform v2](https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-platform-intro) as the test runner. Code coverage is generated in Cobertura format for SonarQube compatibility. For xUnit integration, see [xUnit with Microsoft Testing Platform](https://xunit.net/docs/getting-started/v3/microsoft-testing-platform).
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Opinionated action for dotnet workflows. Restores, checks formatting, lints, bui
 
 - The `working-directory` must contain a single .NET solution or project compatible with the specified .NET SDK version.
 - [CSharpier](https://csharpier.com) must be installed in the working directory or an ancestor directory (e.g., via `dotnet tool install csharpier --create-manifest-if-needed`).
-- From v3 onwards, this action uses [Microsoft Testing Platform v2](https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-platform-intro) as the test runner. Code coverage is generated in OpenCover format for SonarQube compatibility. For xUnit integration, see [xUnit with Microsoft Testing Platform](https://xunit.net/docs/getting-started/v3/microsoft-testing-platform).
+- From v3 onwards, this action uses [Microsoft Testing Platform v2](https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-platform-intro) as the test runner. Code coverage is generated in Visual Studio Code Coverage XML format for SonarQube compatibility. For xUnit integration, see [xUnit with Microsoft Testing Platform](https://xunit.net/docs/getting-started/v3/microsoft-testing-platform).
 
 ## Inputs
 

--- a/action.yml
+++ b/action.yml
@@ -103,7 +103,7 @@ runs:
     - name: Begin SonarQube analysis
       if: inputs.enable-sonar == 'true'
       run: |
-        SONAR_ARGS="/k:${{ inputs.sonar-project-key }} /o:${{ inputs.sonar-organization }} /d:sonar.token=${{ inputs.sonar-token }} /d:sonar.host.url=https://SonarQube.io"
+        SONAR_ARGS="/k:${{ inputs.sonar-project-key }} /o:${{ inputs.sonar-organization }} /d:sonar.token=${{ inputs.sonar-token }}"
         if [ -n "${{ inputs.sonar-exclusions }}" ]; then
           SONAR_ARGS="$SONAR_ARGS /d:sonar.exclusions=${{ inputs.sonar-exclusions }}"
         fi

--- a/action.yml
+++ b/action.yml
@@ -10,19 +10,19 @@ inputs:
     description: "The version of dotnet to use"
     default: "10.0.x"
   enable-sonar:
-    description: "Enable SonarCube analysis"
+    description: "Enable SonarQube analysis"
     default: "false"
   sonar-token:
-    description: "SonarCube token"
+    description: "SonarQube token"
     required: false
   sonar-project-key:
-    description: "SonarCube project key"
+    description: "SonarQube project key"
     required: false
   sonar-organization:
-    description: "SonarCube organization"
+    description: "SonarQube organization"
     required: false
   sonar-exclusions:
-    description: "Comma-separated list of file patterns to exclude from SonarCube analysis (e.g., '**/Migrations/**,**/obj/**')"
+    description: "Comma-separated list of file patterns to exclude from SonarQube analysis (e.g., '**/Migrations/**,**/obj/**')"
     required: false
     default: ""
 
@@ -41,7 +41,7 @@ runs:
       with:
         dotnet-version: ${{ inputs.dotnet-version }}
 
-    - name: Cache SonarCube packages
+    - name: Cache SonarQube packages
       if: inputs.enable-sonar == 'true'
       uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7 # v5
       with:
@@ -49,7 +49,7 @@ runs:
         key: ${{ runner.os }}-sonar
         restore-keys: ${{ runner.os }}-sonar
 
-    - name: Cache SonarCube scanner
+    - name: Cache SonarQube scanner
       if: inputs.enable-sonar == 'true'
       id: cache-sonar-scanner
       uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7 # v5
@@ -58,7 +58,7 @@ runs:
         key: ${{ runner.os }}-sonar-scanner
         restore-keys: ${{ runner.os }}-sonar-scanner
 
-    - name: Install SonarCube scanner
+    - name: Install SonarQube scanner
       if: inputs.enable-sonar == 'true' && steps.cache-sonar-scanner.outputs.cache-hit != 'true'
       run: |
         mkdir -p ${{ runner.temp }}/scanner
@@ -100,10 +100,10 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       shell: bash
 
-    - name: Begin SonarCube analysis
+    - name: Begin SonarQube analysis
       if: inputs.enable-sonar == 'true'
       run: |
-        SONAR_ARGS="/k:${{ inputs.sonar-project-key }} /o:${{ inputs.sonar-organization }} /d:sonar.token=${{ inputs.sonar-token }} /d:sonar.host.url=https://SonarCube.io"
+        SONAR_ARGS="/k:${{ inputs.sonar-project-key }} /o:${{ inputs.sonar-organization }} /d:sonar.token=${{ inputs.sonar-token }} /d:sonar.host.url=https://SonarQube.io"
         if [ -n "${{ inputs.sonar-exclusions }}" ]; then
           SONAR_ARGS="$SONAR_ARGS /d:sonar.exclusions=${{ inputs.sonar-exclusions }}"
         fi
@@ -121,7 +121,7 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       shell: bash
 
-    - name: End SonarCube analysis
+    - name: End SonarQube analysis
       if: inputs.enable-sonar == 'true'
       run: |
         ${{ runner.temp }}/scanner/dotnet-sonarscanner end /d:sonar.token="${{ inputs.sonar-token }}"

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,23 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Validate SonarQube inputs
+      if: inputs.enable-sonar == 'true'
+      run: |
+        if [ -z "${{ inputs.sonar-token }}" ]; then
+          echo "::error::sonar-token is required when enable-sonar is true"
+          exit 1
+        fi
+        if [ -z "${{ inputs.sonar-organization }}" ]; then
+          echo "::error::sonar-organization is required when enable-sonar is true"
+          exit 1
+        fi
+        if [ -z "${{ inputs.sonar-project-key }}" ]; then
+          echo "::error::sonar-project-key is required when enable-sonar is true"
+          exit 1
+        fi
+      shell: bash
+
     - name: Set up JDK 17
       if: inputs.enable-sonar == 'true'
       uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
@@ -103,7 +120,10 @@ runs:
     - name: Begin SonarQube analysis
       if: inputs.enable-sonar == 'true'
       run: |
-        SONAR_ARGS="/k:${{ inputs.sonar-project-key }} /o:${{ inputs.sonar-organization }} /d:sonar.token=${{ inputs.sonar-token }}"
+        SONAR_ARGS="/o:${{ inputs.sonar-organization }}"
+        SONAR_ARGS="$SONAR_ARGS /k:${{ inputs.sonar-project-key }}"
+        SONAR_ARGS="$SONAR_ARGS /d:sonar.token=${{ inputs.sonar-token }}"
+        SONAR_ARGS="$SONAR_ARGS /d:sonar.cs.opencover.reportsPaths=**/coverage.cobertura.xml"
         if [ -n "${{ inputs.sonar-exclusions }}" ]; then
           SONAR_ARGS="$SONAR_ARGS /d:sonar.exclusions=${{ inputs.sonar-exclusions }}"
         fi

--- a/action.yml
+++ b/action.yml
@@ -123,7 +123,7 @@ runs:
         SONAR_ARGS="/o:${{ inputs.sonar-organization }}"
         SONAR_ARGS="$SONAR_ARGS /k:${{ inputs.sonar-project-key }}"
         SONAR_ARGS="$SONAR_ARGS /d:sonar.token=${{ inputs.sonar-token }}"
-        SONAR_ARGS="$SONAR_ARGS /d:sonar.cs.opencover.reportsPaths=**/coverage.opencover.xml"
+        SONAR_ARGS="$SONAR_ARGS /d:sonar.cs.vscoveragexml.reportsPaths=**/coverage.xml"
         if [ -n "${{ inputs.sonar-exclusions }}" ]; then
           SONAR_ARGS="$SONAR_ARGS /d:sonar.exclusions=${{ inputs.sonar-exclusions }}"
         fi
@@ -137,7 +137,7 @@ runs:
       shell: bash
 
     - name: Test
-      run: dotnet test -- --coverage --coverage-output-format opencover --coverage-output coverage.opencover.xml
+      run: dotnet test -- --coverage --coverage-output-format xml --coverage-output coverage.xml
       working-directory: ${{ inputs.working-directory }}
       shell: bash
 

--- a/action.yml
+++ b/action.yml
@@ -123,7 +123,7 @@ runs:
         SONAR_ARGS="/o:${{ inputs.sonar-organization }}"
         SONAR_ARGS="$SONAR_ARGS /k:${{ inputs.sonar-project-key }}"
         SONAR_ARGS="$SONAR_ARGS /d:sonar.token=${{ inputs.sonar-token }}"
-        SONAR_ARGS="$SONAR_ARGS /d:sonar.cs.cobertura.reportsPaths=**/coverage.cobertura.xml"
+        SONAR_ARGS="$SONAR_ARGS /d:sonar.cs.opencover.reportsPaths=**/coverage.opencover.xml"
         if [ -n "${{ inputs.sonar-exclusions }}" ]; then
           SONAR_ARGS="$SONAR_ARGS /d:sonar.exclusions=${{ inputs.sonar-exclusions }}"
         fi
@@ -137,7 +137,7 @@ runs:
       shell: bash
 
     - name: Test
-      run: dotnet test -- --coverage --coverage-output-format cobertura --coverage-output coverage.cobertura.xml
+      run: dotnet test -- --coverage --coverage-output-format opencover --coverage-output coverage.opencover.xml
       working-directory: ${{ inputs.working-directory }}
       shell: bash
 

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: "Build .NET"
 author: "Arbeidstilsynet"
-description: "Restores, checks formatting, lints, builds, and tests a .NET solution/project"
+description: "Restores, checks formatting, lints, builds, and tests a .NET solution/project. Can optionally run SonarQube Cloud analysis."
 
 inputs:
   working-directory:
@@ -15,14 +15,14 @@ inputs:
   sonar-token:
     description: "SonarQube token"
     required: false
-  sonar-project-key:
-    description: "SonarQube project key"
-    required: false
   sonar-organization:
     description: "SonarQube organization"
     required: false
+  sonar-project-key:
+    description: "SonarQube project key"
+    required: false
   sonar-exclusions:
-    description: "Comma-separated list of file patterns to exclude from SonarQube analysis (e.g., '**/Migrations/**,**/obj/**')"
+    description: "Comma-separated list of file patterns to exclude from SonarQube analysis (e.g., '**/Migrations/**,**/Utils/**')"
     required: false
     default: ""
 

--- a/action.yml
+++ b/action.yml
@@ -123,7 +123,7 @@ runs:
         SONAR_ARGS="/o:${{ inputs.sonar-organization }}"
         SONAR_ARGS="$SONAR_ARGS /k:${{ inputs.sonar-project-key }}"
         SONAR_ARGS="$SONAR_ARGS /d:sonar.token=${{ inputs.sonar-token }}"
-        SONAR_ARGS="$SONAR_ARGS /d:sonar.cs.opencover.reportsPaths=**/coverage.cobertura.xml"
+        SONAR_ARGS="$SONAR_ARGS /d:sonar.cs.cobertura.reportsPaths=**/coverage.cobertura.xml"
         if [ -n "${{ inputs.sonar-exclusions }}" ]; then
           SONAR_ARGS="$SONAR_ARGS /d:sonar.exclusions=${{ inputs.sonar-exclusions }}"
         fi


### PR DESCRIPTION
Follow-up fixes for #19

- Update docs
- Validate required inputs when `enable-sonar`
- Attempt to collect coverage with `sonar.cs.vscoveragexml.reportsPaths` and switch coverage output in test step